### PR TITLE
Fixed includes of extended templates

### DIFF
--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -56,12 +56,20 @@ export = class PugAsset extends Asset {
 
   public collectDependencies(): void {
     walk(this.ast, node => {
-      if (node.filename !== this.name && !this.dependencies.has(node.filename)) {
-        this.addDependency(node.filename, {
-          name: node.filename,
-          includedInParent: true
-        });
-      }
+      const recursiveCollect = node => {
+        if (node.nodes) {
+          node.nodes.forEach(n => recursiveCollect(n))
+        } else {
+          if (node.filename && node.filename !== this.name && !this.dependencies.has(node.filename)) {
+          this.addDependency(node.filename, {
+            name: node.filename,
+            includedInParent: true
+          });
+        }
+        }
+      };
+
+      recursiveCollect(node);
 
       if (node.attrs) {
         for (const attr of node.attrs) {

--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -56,9 +56,9 @@ export = class PugAsset extends Asset {
 
   public collectDependencies(): void {
     walk(this.ast, node => {
-      const recursiveCollect = cNode => {
+      const recursiveCollect = (cNode: any) => {
         if (cNode.nodes) {
-          cNode.nodes.forEach(n => recursiveCollect(n));
+          cNode.nodes.forEach((n: any) => recursiveCollect(n));
         } else {
           if (cNode.filename && cNode.filename !== this.name && !this.dependencies.has(cNode.filename)) {
           this.addDependency(cNode.filename, {

--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -58,7 +58,7 @@ export = class PugAsset extends Asset {
     walk(this.ast, node => {
       const recursiveCollect = cNode => {
         if (cNode.nodes) {
-          cNode.nodes.forEach(n => recursiveCollect(n))
+          cNode.nodes.forEach(n => recursiveCollect(n));
         } else {
           if (cNode.filename && cNode.filename !== this.name && !this.dependencies.has(cNode.filename)) {
           this.addDependency(cNode.filename, {

--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -56,14 +56,14 @@ export = class PugAsset extends Asset {
 
   public collectDependencies(): void {
     walk(this.ast, node => {
-      const recursiveCollect = node => {
-        if (node.nodes) {
-          node.nodes.forEach(n => recursiveCollect(n))
+      const recursiveCollect = cNode => {
+        if (cNode.nodes) {
+          cNode.nodes.forEach(n => recursiveCollect(n))
         } else {
-          if (node.filename && node.filename !== this.name && !this.dependencies.has(node.filename)) {
-          this.addDependency(node.filename, {
-            name: node.filename,
-            includedInParent: true
+          if (cNode.filename && cNode.filename !== this.name && !this.dependencies.has(cNode.filename)) {
+          this.addDependency(cNode.filename, {
+            name: cNode.filename,
+            includedInParent: true,
           });
         }
         }


### PR DESCRIPTION
I had a case where parcel would crash during the bundling step because one of the dependencies had a filename set to `undefined`. This crash would happen whenever I tried to include a template that was itself extending another template.

To reproduce the problem, these are the 3 minimal files needed:

`index.pug`:
```
p Index
include extended.pug
```

`extended.pug`:
```
extends model.pug

block content
  p Extended
```

`model.pug`:
```
p Model
block content
```

So in theory, when building `index.pug`, the result should be:

```
p Index
p Model
p Extended
```

But instead the parcel crashed and when investigating the source of the crash, I noticed that the parcel bundler was trying to resolve an asset with a filename of `undefined`.

Upon further investigation, I pinpointed the source of the problem to the function `collectDependencies()` which was adding an object to the dependencies with a filename set to `undefined`.

The cause was that one of the nodes in the `ast` object did not have a `filename` field but instead had a `nodes` field which was an array containing sub-nodes (which in turn might or might not have a `filename` field.

So this pull request contains two changes:

1. I added a check on `filename` to see if it exists before adding it to the dependencies (and avoid a bundler crash)
2. I added a recursive function to check each node but also recursively traverse the sub levels of the node tree and add the necessary filenames from those sub-nodes.