### PR TITLE
Fixed resolving dependencies inside tag attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.2.5"></a>
+## [0.2.5](https://github.com/Ty3uK/parcel-plugin-pug/compare/v0.2.4...v0.2.5) (2018-02-04)
+
+
+### Bug Fixes
+
+* `asset.shouldInvalidate is not a function` error ([0c9b1ff](https://github.com/Ty3uK/parcel-plugin-pug/commit/0c9b1ff))
+
+
+
 <a name="0.2.4"></a>
 ## [0.2.4](https://github.com/Ty3uK/parcel-plugin-pug/compare/v0.2.3...v0.2.4) (2018-01-13)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-pug",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Pug template support for Parcel bundler",
   "repository": "https://github.com/Ty3uK/parcel-plugin-pug.git",
   "main": "build/index.js",
@@ -24,7 +24,9 @@
   "devDependencies": {
     "@types/node": "^8.0.58",
     "husky": "^0.14.3",
+    "jest": "^22.0.6",
     "npm-run-all": "^4.1.2",
+    "parcel-bundler": "^1.4.1",
     "standard-version": "^4.2.0",
     "tslint": "^5.8.0",
     "tslint-eslint-rules": "^4.1.1",

--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -38,6 +38,7 @@ const ATTRS: Dictionary<string[]> = {
     'iframe',
     'embed'
   ],
+  srcset: ['img'],
   href: ['link', 'a'],
   poster: ['video']
 };

--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -56,12 +56,20 @@ export = class PugAsset extends Asset {
 
   public collectDependencies(): void {
     walk(this.ast, node => {
-      if (node.filename !== this.name && !this.dependencies.has(node.filename)) {
-        this.addDependency(node.filename, {
-          name: node.filename,
-          includedInParent: true
-        });
-      }
+      const recursiveCollect = node => {
+        if (node.nodes) {
+          node.nodes.forEach(n => recursiveCollect(n))
+        } else {
+          if (node.filename && node.filename !== this.name && !this.dependencies.has(node.filename)) {
+          this.addDependency(node.filename, {
+            name: node.filename,
+            includedInParent: true
+          });
+        }
+        }
+      };
+
+      recursiveCollect(node);
 
       if (node.attrs) {
         for (const attr of node.attrs) {

--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -56,9 +56,9 @@ export = class PugAsset extends Asset {
 
   public collectDependencies(): void {
     walk(this.ast, node => {
-      const recursiveCollect = cNode => {
+      const recursiveCollect = (cNode: any) => {
         if (cNode.nodes) {
-          cNode.nodes.forEach(n => recursiveCollect(n));
+          cNode.nodes.forEach((n: any) => recursiveCollect(n));
         } else {
           if (cNode.filename && cNode.filename !== this.name && !this.dependencies.has(cNode.filename)) {
           this.addDependency(cNode.filename, {

--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -51,7 +51,6 @@ const PURE_STRING_REGEX: RegExp = /(^"([^"]+)"$)|(^'([^']+)'$)/g;
 
 export = class PugAsset extends Asset {
   public type = 'html';
-  public hasUnresolvedDependencies = false;
 
   constructor(name: string, pkg: string, options: any) {
     super(name, pkg, options);
@@ -99,9 +98,6 @@ export = class PugAsset extends Asset {
                 // from \path\to\res.js to /path/to/res.js
                 assetPath = url.resolve(path.join(this.options.publicURL, assetPath), '');
               }
-              attr.val = `'${assetPath}'`;
-            } else {
-              this.hasUnresolvedDependencies = true;
             }
           }
         }
@@ -113,13 +109,11 @@ export = class PugAsset extends Asset {
   public async process(): Promise<any> {
     await super.process();
 
-    if (this.hasUnresolvedDependencies) {
-      const htmlAsset = new HTMLAsset(this.name, this.package, this.options);
-      htmlAsset.contents = this.generated.html;
-      await htmlAsset.process();
+    const htmlAsset = new HTMLAsset(this.name, this.package, this.options);
+    htmlAsset.contents = this.generated.html;
+    await htmlAsset.process();
 
-      Object.assign(this, htmlAsset);
-    }
+    Object.assign(this, htmlAsset);
 
     return this.generated;
   }

--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -58,7 +58,7 @@ export = class PugAsset extends Asset {
     walk(this.ast, node => {
       const recursiveCollect = cNode => {
         if (cNode.nodes) {
-          cNode.nodes.forEach(n => recursiveCollect(n))
+          cNode.nodes.forEach(n => recursiveCollect(n));
         } else {
           if (cNode.filename && cNode.filename !== this.name && !this.dependencies.has(cNode.filename)) {
           this.addDependency(cNode.filename, {

--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -1,9 +1,5 @@
-import url = require('url');
-import path = require('path');
-
 import { Asset } from './Asset';
 import HTMLAsset = require('parcel-bundler/lib/assets/HTMLAsset');
-import isURL = require('parcel-bundler/lib/utils/is-url');
 
 import load = require('pug-load');
 import lexer = require('pug-lexer');
@@ -91,13 +87,8 @@ export = class PugAsset extends Asset {
           const elements = ATTRS[attr.name];
           if (node.type === 'Tag' && elements && elements.indexOf(node.name) > -1) {
             if (PURE_STRING_REGEX.test(attr.val)) {
-              let assetPath = attr.val.substring(1, attr.val.length - 1);
-              assetPath = this.addURLDependency(assetPath);
-              if (!isURL(assetPath)) {
-                // Use url.resolve to normalize path for windows
-                // from \path\to\res.js to /path/to/res.js
-                assetPath = url.resolve(path.join(this.options.publicURL, assetPath), '');
-              }
+              const assetPath = attr.val.substring(1, attr.val.length - 1);
+              this.addURLDependency(assetPath);
             }
           }
         }

--- a/src/PugAsset.ts
+++ b/src/PugAsset.ts
@@ -56,14 +56,14 @@ export = class PugAsset extends Asset {
 
   public collectDependencies(): void {
     walk(this.ast, node => {
-      const recursiveCollect = node => {
-        if (node.nodes) {
-          node.nodes.forEach(n => recursiveCollect(n))
+      const recursiveCollect = cNode => {
+        if (cNode.nodes) {
+          cNode.nodes.forEach(n => recursiveCollect(n))
         } else {
-          if (node.filename && node.filename !== this.name && !this.dependencies.has(node.filename)) {
-          this.addDependency(node.filename, {
-            name: node.filename,
-            includedInParent: true
+          if (cNode.filename && cNode.filename !== this.name && !this.dependencies.has(cNode.filename)) {
+          this.addDependency(cNode.filename, {
+            name: cNode.filename,
+            includedInParent: true,
           });
         }
         }

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -28,11 +28,6 @@ declare module 'parcel-bundler/lib/assets/HTMLAsset' {
   export = HTMLAsset;
 }
 
-declare module 'parcel-bundler/lib/utils/is-url' {
-  function isURL(url: string): boolean;
-  export = isURL;
-}
-
 declare module 'pug-load' {
   class load {
     static string(str: string, options?: any): any;


### PR DESCRIPTION
This PR is meant to fix the bug that occurred when using any kind of variable or interpolated string inside a tag attribute of types `src`, `href`, or `poster`.

Issue #10 is an example of this bug. In my case, it happened while trying to set an `href` attribute using a variable.

The build crash itself was caused by a lack of checking before adding the dependencies which resulted in Parcel trying to resolve a dependency that did not exist.

I added a regex to check whether the attribute value is actually a pure string or if it is a variable that needs to be evaluated first. The code now only adds the dependency if it's a pure string, which removes the crash.

However, this was not enough to fix the actual behaviour bug. The string now gets evaluated but if the results of the string interpolation is a resource then it is not added to the list of dependencies (since it's not a pure string) and the resource path is not replaced by the hash.

In order to do this while only being able to modify how `PugAsset.js` works, I added an extra step in case a non-pure attribute is detected during the dependency collection stage.

If so, `PugAsset.js` would first process the pug code by itself, which would generate html code.
Then, it will create an intermediate html asset from `HTMLAsset.js` using the generated html code and run its `process()` function (which will, among other things, collect the new interpolated dependencies and add them to the Parcel asset).

This was the only way I could think of to solve this bug without touching the Parcel or Pug files.

I also tried my best to adapt the TypeScript code to the new changes but please double check to see if I got any of them wrong.